### PR TITLE
Min roll

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,10 +1,10 @@
-
 # Coverage config file
 
 [report]
     exclude_lines =
         pragma: no cover
         if __name__ == .__main__.:
+    fail_under = 95.0
 
 [xml]
 output = coverage.xml

--- a/roll/diceparser.py
+++ b/roll/diceparser.py
@@ -25,7 +25,7 @@ Main ::= Expression
 Website used to do railroad diagrams: https://www.bottlecaps.de/rr/ui
 """
 
-from math import ceil, e, factorial, pi, sqrt
+from math import ceil, e, factorial, floor, pi, sqrt
 from operator import add, floordiv, mod, mul, sub, truediv
 from random import randint
 from sys import version_info
@@ -71,13 +71,6 @@ def _roll_dice(
     if sides < 0:
         raise ValueError('The sides of a die must be positive or zero.')
 
-    if isinstance(num_dice, float):
-        sides *= num_dice
-
-        # 0.5d20 == 1d10, so, after we've changed the value,
-        # we need to set the left value to 1.
-        num_dice = 1
-
     result_is_negative = num_dice < 0
 
     if result_is_negative:
@@ -88,9 +81,19 @@ def _roll_dice(
     rolls: List[Union[int, float]] = []
 
     if minimum:
-        rolls = [1] * num_dice
+        rolls = [1] * ceil(num_dice)
     elif sides != 0:
-        rolls = [randint(1, sides) for _ in range(num_dice)]
+        rolls = [randint(1, sides) for _ in range(floor(num_dice))]
+
+        # If it's the case that the number of dice is a float, then
+        # we take that to mean that it is a dice where the sides should
+        # be lowered to reflect the float amount.
+
+        # We do not want this to effect all dice rolls however, only the
+        # last one (or the only one if there's only a decimal portion).
+        if isinstance(num_dice, float) and (num_dice % 1) != 0:
+            sides = ceil(sides * (num_dice % 1))
+            rolls.append(randint(1, sides))
 
     rolls_total = sum(rolls)
 

--- a/roll/diceparser.py
+++ b/roll/diceparser.py
@@ -29,7 +29,7 @@ from math import ceil, e, factorial, pi, sqrt
 from operator import add, floordiv, mod, mul, sub, truediv
 from random import randint
 from sys import version_info
-from typing import List, Union
+from typing import Callable, Dict, List, Optional, Union
 
 # TypedDict was added in 3.8.
 if version_info >= (3, 8):
@@ -51,13 +51,14 @@ class RollResults(TypedDict):
 
 
 class EvaluationResults(TypedDict):
-    total: Union[int, float, None]
+    total: Union[int, float]
     rolls: List[RollResults]
 
 
 def _roll_dice(
         num_dice: Union[int, float],
-        sides: Union[int, float]
+        sides: Union[int, float],
+        minimum: bool = False,
         ) -> RollResults:
     """Calculate value of dice roll notation."""
     starting_num_dice = num_dice
@@ -84,9 +85,12 @@ def _roll_dice(
 
     sides = ceil(sides)
 
-    rolls: List[Union[int, float]] = [
-        randint(1, sides) for _ in range(num_dice)
-    ] if sides != 0 else []
+    rolls: List[Union[int, float]] = []
+
+    if minimum:
+        rolls = [1] * num_dice
+    elif sides != 0:
+        rolls = [randint(1, sides) for _ in range(num_dice)]
 
     rolls_total = sum(rolls)
 
@@ -105,7 +109,20 @@ def _roll_dice(
 class DiceParser:
     """Parser for evaluating dice strings."""
 
-    operations = {
+    operations: Dict[
+        str,
+        Union[
+            Callable[
+                [
+                    Union[int, float],
+                    Union[int, float]
+                ], Union[int, float, RollResults]],
+            # This is needed for factorial and sqrt
+            Callable[
+                [Union[int, float]],
+                Union[int, float]
+            ]
+        ]] = {
         "+": add,
         "-": sub,
         "*": mul,
@@ -170,7 +187,8 @@ class DiceParser:
 
     def evaluate(
             self: "DiceParser",
-            parsed_values: Union[List[Union[str, int]], str]
+            parsed_values: Union[List[Union[str, int]], str],
+            minimum: bool = False
     ) -> EvaluationResults:
         """Evaluate the output parsed values from roll strings."""
         if isinstance(parsed_values, str):
@@ -180,7 +198,7 @@ class DiceParser:
         operator = None
         dice_rolls = []
 
-        val: Union[str, int, float]
+        val: Union[str, int, float, Optional[float]]
         for val in parsed_values:
 
             # In addition to dealing with values, we are also going to
@@ -192,9 +210,9 @@ class DiceParser:
                     val in self.constants
             ):
                 if val in self.constants:
-                    val = self.constants[val]
+                    val = self.constants[str(val)]
                 elif isinstance(val, ParseResults):
-                    evaluation = self.evaluate(val)
+                    evaluation: EvaluationResults = self.evaluate(val, minimum)
                     val = evaluation['total']
                     dice_rolls.extend(evaluation['rolls'])
 
@@ -211,7 +229,7 @@ class DiceParser:
                             result = 0
 
                     if operator is _roll_dice:
-                        current_rolls = operator(result, val)
+                        current_rolls = _roll_dice(result, val, minimum)
 
                         result = current_rolls['total']
                         dice_rolls.append(current_rolls)
@@ -228,23 +246,20 @@ class DiceParser:
                 # hand side, we will execute the factorial function here
                 # as we do not have to wait for any further input.
                 if val == "!":
-                    result = factorial(result)
+                    result = factorial(result if result is not None else 0)
                     continue
 
                 operator = self.operations[val]
 
             elif val in ["D%", "d%"]:
                 current_rolls = _roll_dice(
-                    result if result is not None else 1, 100)
+                    result if result is not None else 1, 100, minimum)
 
                 result = current_rolls['total']
                 dice_rolls.append(current_rolls)
 
-            else:
-                raise ValueError("Unable to evaluate input.")
-
         total_results: EvaluationResults = {
-            'total': result,
+            'total': result if result is not None else 0,
             'rolls': dice_rolls
         }
 

--- a/roll/roll.py
+++ b/roll/roll.py
@@ -15,16 +15,19 @@ etc.
 """
 from typing import Union
 
-import roll.diceparser as dp
+from roll.diceparser import DiceParser, EvaluationResults
 
-_DICE_PARSER = dp.DiceParser()
+_DICE_PARSER = DiceParser()
+
+GOOD_CHARS: str = "0123456789d-/*() %+.!^piesqrt"
 
 
 def roll(expression: str = '',
-         verbose: bool = False) -> Union[int, float, dp.EvaluationResults]:
+         verbose: bool = False,
+         minimum: bool = False
+         ) -> Union[int, float, EvaluationResults]:
     """Evalute a string for dice and mathematical operations and calculate."""
-    bad_chars: str = "0123456789d-/*() %+.!^piesqrt"
-    input_had_bad_chars: bool = len(expression.strip(bad_chars)) > 0
+    input_had_bad_chars: bool = len(expression.strip(GOOD_CHARS)) > 0
 
     if input_had_bad_chars:
         raise ValueError('Input contained invalid characters.')
@@ -32,7 +35,7 @@ def roll(expression: str = '',
     if expression.strip() == '':
         expression = "1d20"
 
-    result = _DICE_PARSER.evaluate(expression)
+    result: EvaluationResults = _DICE_PARSER.evaluate(expression, minimum)
 
     if verbose:
         return result

--- a/tests/test_basic_math.py
+++ b/tests/test_basic_math.py
@@ -1,5 +1,5 @@
 
-from math import e, pi, sqrt
+import math
 from typing import Union
 
 import pytest
@@ -150,8 +150,8 @@ def test_add_explonential():
 
 
 @pytest.mark.parametrize("equation,result", [
-    ('pi', pi),
-    ('e', e),
+    ('pi', math.pi),
+    ('e', math.e),
 ])
 def test_constants(equation: str, result: Union[int, float]):
     assert roll(equation) == result
@@ -175,8 +175,8 @@ def test_constants(equation: str, result: Union[int, float]):
     ('sqrt --16', 4),
     ('- sqrt 49', -7),
     # Constants
-    ('sqrt e', sqrt(e)),
-    ('sqrt pi', sqrt(pi)),
+    ('sqrt e', math.sqrt(math.e)),
+    ('sqrt pi', math.sqrt(math.pi)),
     # Exponentiation
     ('sqrt 169 ** 2', 169),
     ('5 ** sqrt 9', 125),

--- a/tests/test_click.py
+++ b/tests/test_click.py
@@ -20,7 +20,6 @@ def test_roll_with_input():
 
 def test_verbose_output():
     result = runner.invoke(roll_cli, ["4d6", "-v"])
-    print(result.output)
     assert result.exit_code == 0
     assert "4d6: [" in result.output
     assert int(result.output.split()[-1]) in range(4, 25)
@@ -28,8 +27,14 @@ def test_verbose_output():
 
 def test_verbose_ouput_mult_dice():
     result = runner.invoke(roll_cli, ["4d6 + 5d10", "-v"])
-    print(result.output)
     assert result.exit_code == 0
     assert "4d6: [" in result.output
     assert "5d10: [" in result.output
     assert int(result.output.split()[-1]) in range(9, 75)
+
+
+def test_min_roll():
+    result = runner.invoke(roll_cli, ["5d6", "-m", "-v"])
+    print(result.output)
+    assert result.exit_code == 0
+    assert int(result.output.split()[-1]) == 5

--- a/tests/test_dice_rolling.py
+++ b/tests/test_dice_rolling.py
@@ -9,26 +9,25 @@ def test_basic_roll():
     assert result in range(1, 21)
 
 
+@pytest.mark.parametrize('equation,range_low,range_high', [
+    ('', 1, 20),
+    ('d20', 1, 20),
+    ('1d20', 1, 20),
+    ('-1d20', -20, 0),
+    ('100.0d6', 100, 600),
+    ('100d6.0', 100, 600),
+    ('2.0d100.0', 2, 200),
+])
+def test_roll(equation: str, range_low: int, range_high: int):
+    assert roll(equation) in range(range_low, range_high + 1)
+
+
 def test_zero_dice_roll():
     assert roll('0d20') == 0
 
 
 def test_zero_sided_dice_roll():
     assert roll('1d0') == 0
-
-
-def test_d20():
-    assert roll('d20') in range(1, 21)
-
-
-def test_1d20():
-    result = roll('1d20')
-    assert type(result) == int
-    assert result in range(1, 21)
-
-
-def test_neg1d20():
-    assert roll('-1d20') in range(-20, 0)
 
 
 def test_1d_neg20():

--- a/tests/test_dice_rolling.py
+++ b/tests/test_dice_rolling.py
@@ -17,6 +17,8 @@ def test_basic_roll():
     ('100.0d6', 100, 600),
     ('100d6.0', 100, 600),
     ('2.0d100.0', 2, 200),
+    ('100.5d6', 101, 603),
+    ('1.0d6.5', 1, 7),
 ])
 def test_roll(equation: str, range_low: int, range_high: int):
     assert roll(equation) in range(range_low, range_high + 1)

--- a/tests/test_dice_rolling_with_math.py
+++ b/tests/test_dice_rolling_with_math.py
@@ -40,4 +40,7 @@ def test_dice_expo1():
     ('1d sqrt 36', 1, 6),
 ])
 def test_dice_sqrt(equation: str, range_low: int, range_high: int):
-    assert roll(equation) in range(range_low, range_high + 1)
+    result = roll(equation, verbose=True)
+    print(result)
+    total = result['total']
+    assert total in range(range_low, range_high + 1)


### PR DESCRIPTION
feat: Added the ability to specify that the dice should return their minimum possible value.
fix: Fixed issue with percentage chances for dice where the number was supplied as a float.
test: Added further testing to ensure minimum flag works and the fix for float num_dice was corrected.

Closes issues #15, #32